### PR TITLE
Simplify RefCheckArena to peer ratings

### DIFF
--- a/refcheckarena/refcheckarena_demo.py
+++ b/refcheckarena/refcheckarena_demo.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Iterable
+
+from agents import Agent, Runner, trace
+
+
+@dataclass
+class ReferenceCheck:
+    collaboration: int
+    handoff_clarity: int
+    reliability: int
+    communication: int
+    initiative: int
+    overall: int
+    rationale: str
+
+
+def build_reference_checker(name: str) -> Agent[None]:
+    rubric = (
+        "Rate the colleague using 1-5 integers for each dimension. "
+        "Use 1 for poor and 5 for excellent. Provide an overall rating and a brief rationale."
+    )
+    instructions = (
+        "You are a reference checker evaluating a colleague after working together on a task. "
+        "Be direct, specific, and grounded in the provided task context. "
+        f"{rubric}"
+    )
+    return Agent(name=name, instructions=instructions, output_type=ReferenceCheck)
+
+
+def aggregate_checks(checks: Iterable[ReferenceCheck]) -> dict[str, float]:
+    totals = {
+        "collaboration": 0,
+        "handoff_clarity": 0,
+        "reliability": 0,
+        "communication": 0,
+        "initiative": 0,
+        "overall": 0,
+    }
+    count = 0
+    for check in checks:
+        totals["collaboration"] += check.collaboration
+        totals["handoff_clarity"] += check.handoff_clarity
+        totals["reliability"] += check.reliability
+        totals["communication"] += check.communication
+        totals["initiative"] += check.initiative
+        totals["overall"] += check.overall
+        count += 1
+
+    if count == 0:
+        return {key: 0.0 for key in totals}
+
+    return {key: value / count for key, value in totals.items()}
+
+
+async def run_team_task(
+    task_prompt: str,
+    team: list[Agent],
+) -> dict[str, object]:
+    team_outputs: dict[str, str] = {}
+    for agent in team:
+        result = await Runner.run(agent, task_prompt)
+        team_outputs[agent.name] = result.final_output
+
+    return {
+        "task": task_prompt,
+        "team_outputs": team_outputs,
+    }
+
+
+async def collect_peer_checks(
+    task_prompt: str,
+    team_outputs: dict[str, str],
+) -> dict[str, dict[str, ReferenceCheck]]:
+    checks: dict[str, dict[str, ReferenceCheck]] = {}
+    for rater, subject in combinations(team_outputs.keys(), 2):
+        for evaluator, target in ((rater, subject), (subject, rater)):
+            checker = build_reference_checker(name=f"{evaluator}_rates_{target}")
+            context = (
+                "Task prompt:\n"
+                f"{task_prompt}\n\n"
+                "Your output:\n"
+                f"{team_outputs[evaluator]}\n\n"
+                "Colleague output:\n"
+                f"{team_outputs[target]}"
+            )
+            result = await Runner.run(checker, context)
+            checks.setdefault(evaluator, {})[target] = result.final_output
+    return checks
+
+
+async def main() -> None:
+    tasks = [
+        "Draft a concise project update and hand off next steps to a teammate.",
+        "Propose a plan for debugging a flaky test and specify who does what.",
+    ]
+
+    team = [
+        Agent(
+            name="Planner",
+            instructions=(
+                "You are a concise project planner. Focus on task breakdowns and handoffs."
+            ),
+        ),
+        Agent(
+            name="Implementer",
+            instructions=(
+                "You are an implementation-focused collaborator. Emphasize concrete actions."
+            ),
+        ),
+        Agent(
+            name="Reviewer",
+            instructions=(
+                "You are a reviewer who highlights risks and clarifies communication."
+            ),
+        ),
+    ]
+
+    results: list[dict[str, object]] = []
+
+    with trace("RefCheckArena demo run"):
+        for task_prompt in tasks:
+            task_result = await run_team_task(task_prompt, team)
+            checks = await collect_peer_checks(
+                task_prompt,
+                task_result["team_outputs"],
+            )
+            task_result["peer_checks"] = checks
+            results.append(task_result)
+
+    for result in results:
+        print("\n=== Task ===")
+        print(result["task"])
+        print("\nTeam outputs:\n")
+        for name, output in result["team_outputs"].items():
+            print(f"[{name}] {output}")
+        print("\nPeer checks:\n")
+        for rater, ratings in result["peer_checks"].items():
+            for subject, check in ratings.items():
+                print(f"{rater} -> {subject}: {check}")
+
+    all_checks = [
+        check
+        for result in results
+        for ratings in result["peer_checks"].values()
+        for check in ratings.values()
+    ]
+    print("\n=== Aggregate ===")
+    print(aggregate_checks(all_checks))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/refcheckarena/refcheckarena_methodology.md
+++ b/refcheckarena/refcheckarena_methodology.md
@@ -1,0 +1,51 @@
+# RefCheckArena methodology sketch grounded in the OpenAI Agents SDK
+
+## Core idea
+RefCheckArena evaluates a set of agents by collecting structured, rubric-based reference checks from their peers after working on shared tasks. This mirrors human reference checks: evaluators focus on collaboration quality, reliability, and communication, not just task correctness.
+
+## SDK-grounded building blocks
+- **Team agents**: multiple `Agent` instances with complementary roles (planner, implementer, reviewer).
+- **Reference checkers**: lightweight evaluator agents instantiated per pairwise check.
+- **Execution**: `Runner.run(...)` to produce each agent’s task response and to run each reference checker.
+- **Structured scoring**: `output_type` with a dataclass (e.g., `ReferenceCheck`) to enforce numeric ratings and rationale.
+- **Tracing**: `trace(...)` to group the full evaluation run and allow later inspection of all subcalls.
+- **Message plumbing**: `TResponseInputItem` and `ItemHelpers` to construct inputs and extract model outputs for reference checkers.
+
+## Proposed evaluation protocol
+1. **Task suite selection**
+   - Assemble a set of tasks that exercise: coordination, delegation, handoff clarity, and error recovery.
+   - Use realistic prompts (e.g., “Draft a project plan, then hand off to a teammate with clear next steps.”).
+
+2. **Team execution**
+   - For each task, run each team agent with `Runner.run(agent, prompt)`.
+   - Capture each agent’s output for downstream checks.
+
+3. **Reference checks (peer ratings)**
+   - For each pair of agents, collect bidirectional ratings.
+   - Each reference checker scores a colleague on a rubric, for example:
+     - **Collaboration** (1–5): readiness to coordinate, invite feedback, and align on goals.
+     - **Handoff clarity** (1–5): concrete next steps, ownership, deadlines.
+     - **Reliability** (1–5): realistic commitments and verification steps.
+     - **Communication** (1–5): concise, structured, and appropriate tone.
+     - **Initiative** (1–5): proactive issue spotting and mitigation.
+
+4. **Aggregation and analysis**
+   - Compute per-task and overall averages across all peer checks.
+   - Compare variance across raters (signal of evaluator agreement).
+   - Correlate with benchmark scores to quantify complementary information.
+
+5. **Optional extensions**
+   - **Role-conditioned evaluators**: different prompts for managers, peers, and cross-functional partners.
+   - **Tool usage audit**: include tool call logs in the evaluator context.
+   - **Longitudinal checks**: multiple tasks over time to approximate “working history.”
+
+## Implementation sketch (script in this repo)
+- `refcheckarena/refcheckarena_demo.py` provides a minimal runnable example:
+  - Defines a small team of agents and runs a short task suite.
+  - Collects bidirectional peer ratings for each task.
+  - Prints peer checks and an aggregate score across all ratings.
+
+## Expected outcomes
+- Reference checks surface interaction quality signals not captured by static benchmarks.
+- Disagreement among reference checkers highlights ambiguous or inconsistent behavior.
+- Aggregated scores can be used alongside benchmark metrics in a composite evaluation suite.


### PR DESCRIPTION
### Motivation

- Move the demo to the simplest reproducible case: a small team of agents that rate each other rather than an external target plus specialized checkers. 
- Focus on compact, pairwise peer checks so the paradigm is easy to run across small task suites and model combinations. 
- Surface interaction-quality signals (handoffs, collaboration, reliability) via a structured rubric rather than just task correctness. 
- Keep the example minimal and SDK-grounded so it can be extended in follow-ups.

### Description

- Replace the previous target-centric demo with a team-based flow implemented in `refcheckarena/refcheckarena_demo.py`, including `run_team_task` and `collect_peer_checks` that run each agent and collect bidirectional peer ratings. 
- Add a `ReferenceCheck` dataclass and `aggregate_checks` function to enforce structured numeric ratings and compute averages. 
- Use `itertools.combinations` for pairwise rater/subject pairs and instantiate lightweight evaluator agents via `build_reference_checker(name)`; run everything with `Runner.run` and group traces with `trace`. 
- Update `refcheckarena/refcheckarena_methodology.md` to describe the team-based protocol and the minimal runnable sketch.

### Testing

- No automated tests were run as part of this change. 
- Linting/formatting and CI test runs were not executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585a21903c832b9ebe414601a7ec08)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a minimal team-based peer evaluation flow and documents the protocol.
> 
> - Adds `refcheckarena_demo.py` that runs a small team of `Agent`s on tasks, collects bidirectional peer ratings via lightweight reference-checker agents (`build_reference_checker`), and aggregates scores with `aggregate_checks`; includes `run_team_task`, `collect_peer_checks`, and tracing with `trace`.
> - Defines `ReferenceCheck` dataclass to enforce structured 1–5 ratings plus rationale; prints per-task outputs, peer checks, and overall aggregates.
> - Adds `refcheckarena_methodology.md` describing the SDK-grounded setup, evaluation protocol, and expected outcomes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b5dddb97431745753c73ef40daaa7f3039e1656. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->